### PR TITLE
fix xml comment for Value property

### DIFF
--- a/src/Codemations.Asn1/AsnPrimitiveElement.cs
+++ b/src/Codemations.Asn1/AsnPrimitiveElement.cs
@@ -9,7 +9,7 @@ namespace Codemations.Asn1
     public sealed class AsnPrimitiveElement : AsnElement
     {
         /// <summary>
-        /// Gets or sets the content encoded value.
+        /// Gets the content encoded value.
         /// </summary>
         public ReadOnlyMemory<byte> Value { get; }
 


### PR DESCRIPTION
## Summary
- clarify Value property documentation to indicate the property is read-only

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689544b63c548320986a3d6aea494b79