### PR TITLE
Use deferred converter resolution

### DIFF
--- a/src/Codemations.Asn1/AsnConverterResolver.cs
+++ b/src/Codemations.Asn1/AsnConverterResolver.cs
@@ -88,7 +88,7 @@ internal class AsnConverterResolver
 
     private IAsnConverter ResolveInternal(Type type)
     {
-        return _cache.GetOrAdd(type, ResolveConverter(type));
+        return _cache.GetOrAdd(type, ResolveConverter);
     }
 
     private IAsnConverter ResolveConverter(Type type)


### PR DESCRIPTION
## Summary
- Update `AsnConverterResolver` to cache converters using a deferred value factory

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689544a7bec0832087fa563db7389df4